### PR TITLE
Standardize URLs for case sensitive environments

### DIFF
--- a/.github/workflows/repo-creation.yml
+++ b/.github/workflows/repo-creation.yml
@@ -185,7 +185,7 @@ jobs:
                     "name": "$env:UMBRACO_PROJECT_NAME EntryPoint",
                     "alias": "$env:UMBRACO_PROJECT_NAME_LOWER.entrypoint",
                     "type": "backofficeEntryPoint",
-                    "js": "/app_plugins/$env:UMBRACO_RCL_PROJECT_NAME/$env:UMBRACO_PROJECT_NAME_LOWER.js"
+                    "js": "/App_Plugins/$env:UMBRACO_RCL_PROJECT_NAME/$env:UMBRACO_PROJECT_NAME_LOWER.js"
                   }
                 ]
           }


### PR DESCRIPTION
Heya @warrenbuckley!  :wave:  This repo creator is fantastic!  :sparkles:

I've been playing around with it more for packages and I came across an issue related to case-sensitivity differences in different dev environments.

When I run the test site in a Mac OS environment, I get a 404 when my browser tries to load the Entry Point JavaScript file.

<img width="1512" alt="Screenshot 2024-06-27 at 12 47 14 PM" src="https://github.com/warrenbuckley/Umbraco-Repo-Template/assets/3477155/facbc918-d690-46f6-bda0-3c84813f4bbb">

Looks like the file is accessible at `App_Plugins/...` on my machine instead of `app_plugins/...`.  I'm not sure if this is related to underlying filesystem differences or a difference between IIS and Kestrel (or both 😅), but this PR makes the capitalization of the manifest's path to the JS file consistent with the capitalization of the static assets path in the package project file.

I'm not able to test this locally on Windows at the moment, so if you're able to, please give it a spin there and let me know if there are any adjustments that I should make.  😄 